### PR TITLE
Update dependencies chapter

### DIFF
--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -30,11 +30,11 @@ There's a number of ways to protect yourself from dependency issues. Some are si
 
 RAP is language and tool-agnostic and so this section provides some ideas that you might consider. Other options are available and you should consider what is best for you based on your infrastructure and the technical knowledge of you, your team and anyone who might work on the project in future.
 
-### Record version numbers
+### Version numbers
 
-One simple way to do this would be to record the packages and their version numbers. Yes, you could literally inspect every package, but there are functions that allow you to do this automatically.
+We can record each package and the version we used during the analysis.
 
-You could use `sessionInfo()` to do this in R.[^sessionInfo]
+For example, you could use `sessionInfo()` in R.[^sessionInfo]
 
 ```{r, eval=FALSE}
 sessionInfo()
@@ -68,7 +68,7 @@ sessionInfo()
 ## [22] htmltools_0.3.6   knitr_1.21        highlight_0.4.7.2
 ```
 
-For Python you can use `pip freeze` in a shell script to achieve a similar thing.[^pip-pin]
+You can achieve a similar thing in Python with `pip freeze` in a shell script.[^pip-pin]
 
 ```{bash, eval=FALSE}
 pip freeze
@@ -83,32 +83,98 @@ pip freeze
 ## argcomplete==1.9.4
 ## asn1crypto==0.24.0
 ## astroid==1.6.3
-## astropy==3.0.2
-## atomicwrites==1.2.1
-## attrs==18.2.0
-## awscli==1.16.31
 ...
 ```
 
-Analysts working on the publication's code in future could look at the version numbers and ensure they download that version rather than the latest.
+But simply saving this information[^save-session] isn't good dependency control. It:
 
-This approach is simple but isn't ideal. It:
-
-* is tedious to do this by hand for each package
-* isn't reproducible because the step between reading the version numbers and installing them isn't automated
-* isn't _isolated_, meaning that you'll overwrite any current versions on your machine globally
-
-What's better?
+* would be tedious for analysts to download each recorded package version one-by-one
+* records _every_ package and its version _on your whole system_; not just the ones relevant to your project
+* isn't a reproducible or automated process
 
 ### Environments for dependency management
 
-Ideally we want to _automate_ the process of recording packages and their version numbers and have them installed in an _isolated environment_ that's specific to our project. Doing this makes the project more _portable_ -- you could run it easily from another machine that's configured differently to your own -- and therfore more _reproducible_ by others.
+Ideally we want to _automate_ the process of recording packages and their version numbers and have them installed in an _isolated environment_ that's specific to our project. Doing this makes the project more _portable_ -- you could run it easily from another machine that's configured differently to your own -- and therfore it would be more _reproducible_.
 
 #### Package managers in R
 
-A popular choice in R is [the `packrat` package](https://rstudio.github.io/packrat/). When working in your project's repository, you can call `packrat::init()` to turn on 'Packrat mode' for your project. This means your package dependencies will now be stored in a _private package library_ that's isolated within the project folder. In this mode, any packages you install within your project are stored in the private library. Regular 'snapshots' are taken to record the state of dependencies.
+A popular choice in R is [the `packrat` package](https://rstudio.github.io/packrat/).
 
-A similar tool is [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics. It works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/). One caveat is that you're dependent on MRAN to continue snapshotting CRAN and for it to continue to be maintained.
+In this example from [Packrat's walkthrough](https://rstudio.github.io/packrat/walkthrough.html) you can see that calling `packrat::init()` in your project's repository causes 'Packrat mode' to activate for that project.
+
+```{r, eval=FALSE}
+packrat::init("~/projects/rap-project")
+```
+```
+Adding these packages to packrat:
+            _         
+    packrat   0.2.0.128
+
+Fetching sources for packrat (0.2.0.128) ... OK (GitHub)
+Snapshot written to '/Users/matt/projects/rap-project/packrat/packrat.lock'
+Installing packrat (0.2.0.128) ... OK (built source)
+init complete!
+Packrat mode on. Using library in directory:
+- "~/projects/rap-project/packrat/lib" 
+```
+
+What happened here? Packrat:
+
+* found a specific version of package in use in the project (itself!)
+* downloaded it to a _private package library_, a new folder within the project for storing packages isolated within that project
+* recorded a snapshot (a bit like saving `sessionInfo()`)
+
+With Packrat mode on, any newly-downloaded packages are saved _within_ your project in the private library. By default, regular snapshots are taken to record the state of dependencies. You can force this with `packrat::snapshot()`. [This example](https://rstudio.github.io/packrat/walkthrough.html) shows a user-initiated snapshot after installing a few packages (`plyr`, `Rcpp`, `reshape2` and `stringr`). You can see that Packrat fetcches the sources and records a snapshot.
+
+```{r, eval=FALSE}
+packrat::snapshot()
+```
+```
+Adding these packages to packrat:
+             _       
+    plyr       1.8.1 
+    Rcpp       0.11.2
+    reshape2   1.4   
+    stringr    0.6.2 
+
+Fetching sources for plyr (1.8.1) ... OK (CRAN current)
+Fetching sources for Rcpp (0.11.2) ... OK (CRAN current)
+Fetching sources for reshape2 (1.4) ... OK (CRAN current)
+Fetching sources for stringr (0.6.2) ... OK (CRAN current)
+Snapshot written to '/Users/matt/projects/rap-project/packrat/packrat.lock'
+```
+
+So far this loooks like an automated version of recording the output of 'sessionInfo()` with a special private library so you're only using specific package versions for your project. When you run this again in future, you'll have the exact versions you need to recreate the analysis. 
+
+Great, but what if a collaborator downloads the package? This is where we see the power of the snapshot. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library. created on that collaborator's machine.
+
+```
+Packrat is not installed in the local library -- attempting to bootstrap an installation...
+> Installing packrat into project private library:
+- '/Users/matt/projects/rap-project/packrat/lib/x86_64-apple-darwin13.1.0/3.2.0'
+* installing *source* package ‘packrat’ ...
+** R
+** inst
+** preparing package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** testing if installed package can be loaded
+* DONE (packrat)
+> Attaching packrat
+> Restoring library
+Installing plyr (1.8.1) ... OK (built source)
+Installing Rcpp (0.11.2) ... OK (built source)
+Installing reshape2 (1.4) ... OK (built source)
+Installing stringr (0.6.2) ... OK (built source)
+> Packrat bootstrap successfully completed. Entering packrat mode...
+Packrat mode on. Using library in directory:
+- "~/projects/babynames/packrat/lib"
+```
+
+Note that [there are some caveats](https://rstudio.github.io/packrat/limitations.html) to using Packrat.
+
+A similar tool to `packrat` is [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics. It works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/). One caveat is that you're dependent on MRAN to continue snapshotting CRAN and for it to continue to be maintained.
 
 #### Virtual environments in Python
 
@@ -118,16 +184,20 @@ We can set up a virtual environment in our project folder, install any modules w
 
 ```{bash, eval=FALSE}
 # 1. Navigate to your project folder
-cd path/to/project/file
+cd ~/projects/rap-project/
 
-# 2. Create a virtual environment (a folder in your home directory)
+# 2. Create a virtual environment folder there
 virtualenv venv
 
 # 3. 'Activate' the virtual environment
 source venv/bin/activate
+```
 
+You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2.
+
+```{bash, eval=FALSE}
 # 4. Install the modules you need
-pip install <name>
+pip install numpy
 
 # 5. Record the package-version list to a file in your home directory
 pip freeze > requirements.txt
@@ -148,9 +218,9 @@ This will download the modules one by one into the virtual environment.
 
 What about the version of the analytical software you're using? You may have written the original code in R version 3.4.1 but your computer is currently running R version 3.5.1. This is a similar problem to the issue of packages and modules: the functioning of code is also dependent on changes to the scripting tool itself.
 
-You need to think bigger than an isolated environment for package installation. We need some kind of isolated environment for both the packages _and_ the tools. And why stop there? We could put our functions, tests and data in there too.
+You can think bigger than an isolated environment for package installation. We need some kind of isolated environment for both the packages _and_ the tools. And why stop there? We could put our functions, tests and data in there too.
 
-A 'container' for our publication is a good idea. We can isolate all the components of our RAP publication and make it even more portable.
+A 'container' for our publication is a good idea. We can isolate all the components of our RAP publication and make it even more reproducible and portable.
 
 ### Docker
 
@@ -158,3 +228,4 @@ One way of doing this is to use Docker.
 
 [^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.
 [^pip-pin]: These should be 'pinned' meaning that they're in the form `module==1.3.2` rather than `module>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.
+[^save-session]: With something like `writeLines(capture.output(sessionInfo()), "sessionInfo.txt")` within R and `pip freeze > requirements.txt` in the shell for Python.

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -18,11 +18,11 @@ Most statistical publications are [updated on a scheduled basis](https://www.gov
 
 It's possible that you'll get some errors when you reuse your RAP project code for the next update, even if everything worked perfectly last time. Why? The maintainers of your dependencies may have changed the code and it no longer works as you expect.
 
-Changes might not impact your publication. If changes do have an impact, the best case is that you'll get a helpful error message. At worst, your code will execute with an impercetible but impactful error. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
+Changes might not impact your publication. If changes do have an impact, the best case is that you'll get a helpful error message. At worst, your code will execute with an imperceptible but impactful error. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
 
 The problem is compounded if your dependencies depend on other dependencies, or if two of your dependencies require conflicting versions of a third dependency. You could get stuck in so-called [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
-The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this?
+The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this? This chapter considers a few possibilities given variation in tools, techniques and IT restrictions.
 
 ### Think lightweight
 
@@ -49,41 +49,36 @@ Maintainers signal updates by increasing the version number of their software. T
 
 There are many ways to record each of the packages used in our analysis and their version numbers.
 
-For example, in R you could use the `sessionInfo()` package.[^sessionInfo] This prints details about the current state of the working environment, including the packages and version numbers. 
+In R you could, for example, use the `session_info()` function from `devtools` package. This prints details about the current state of the working environment. 
 
 ```{r, eval=FALSE}
-sessionInfo()
+devtools::session_info()
 ```
 ```
-## R version 3.5.1 (2018-07-02)
-## Platform: x86_64-apple-darwin15.6.0 (64-bit)
-## Running under: macOS High Sierra 10.13.6
-## 
-## Matrix products: default
-## BLAS: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
-## LAPACK: /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libRlapack.dylib
-## 
-## locale:
-## [1] en_GB.UTF-8/en_GB.UTF-8/en_GB.UTF-8/C/en_GB.UTF-8/en_GB.UTF-8
-## 
-## attached base packages:
-## [1] stats     graphics  grDevices utils     datasets  methods   base     
-## 
-## other attached packages:
-## [1] packrat_0.4.8-1
-## 
-## loaded via a namespace (and not attached):
-##  [1] bookdown_0.7      Rcpp_1.0.0        later_0.7.5      
-##  [4] digest_0.6.18     mime_0.6          R6_2.3.0         
-##  [7] magrittr_1.5      evaluate_0.11     xaringan_0.8     
-## [10] stringi_1.2.4     promises_1.0.1    rstudioapi_0.8   
-## [13] rmarkdown_1.11    tools_3.5.1       servr_0.10       
-## [16] stringr_1.3.1     httpuv_1.4.5      xfun_0.3         
-## [19] yaml_2.2.0        rsconnect_0.8.10  compiler_3.5.1   
-## [22] htmltools_0.3.6   knitr_1.21        highlight_0.4.7.2
+─ Session info ─────────────────────────────────────────
+setting  value                       
+version  R version 3.5.2 (2018-12-20)
+os       macOS High Sierra 10.13.6   
+system   x86_64, darwin15.6.0        
+ui       RStudio                     
+language (EN)                        
+collate  en_GB.UTF-8                 
+ctype    en_GB.UTF-8                 
+tz       Europe/London               
+date     2019-03-01                  
+
+─ Packages ────────────────────────────────────────────
+package     * version    date       lib source                         
+assertthat    0.2.0      2017-04-11 [1] CRAN (R 3.5.0)                 
+backports     1.1.3      2018-12-14 [1] CRAN (R 3.5.0)                 
+bookdown      0.7        2018-02-18 [1] CRAN (R 3.5.0)                 
+callr         3.1.1      2018-12-21 [1] CRAN (R 3.5.0)                 
+...
 ```
 
-You can achieve a similar thing for Python with `pip freeze` in a shell script.[^pip-pin] Again, this provides a list of the packages available in the current environment and their version numbers.
+You could do something like `pkgs <- devtools::session_info()$packages` to save a dataframe of the packages and versions.
+
+You can achieve a similar thing for Python with `pip freeze` in a shell script.
 
 ```{bash, eval=FALSE}
 pip freeze
@@ -95,13 +90,12 @@ pip freeze
 ## anaconda-project==0.8.2
 ## appnope==0.1.0
 ## appscript==1.0.1
-## argcomplete==1.9.4
-## asn1crypto==0.24.0
-## astroid==1.6.3
 ...
 ```
 
-But simply saving this information[^save-session] in your project folder isn't good dependency control. It:
+You can save this information with something like `pip freeze > requirements.txt` in the shell. The packages  should be 'pinned' to specific versions, meaning that they're in the form `packageName==1.3.2` rather than `packageName>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.
+
+But simply saving this information in your project folder isn't good dependency control. It:
 
 * would be tedious for analysts to read these reports and download each recorded package version one-by-one
 * records _every_ package and its version _on your whole system_, not just the ones relevant to your project
@@ -115,16 +109,18 @@ Ideally we want to automate the process of recording packages and their version 
 
 There is currently no consensus approach for package management in R. Below are a few options, but this is a non-exhaustive list.
 
-[The `packrat` package](https://rstudio.github.io/packrat/) is often referred to, but [has its issues](https://rstudio.github.io/packrat/limitations.html). A [walkthrough is available](https://rstudio.github.io/packrat/walkthrough.html), but the basic process is:
+The [`packrat` package](https://rstudio.github.io/packrat/) is commonly used but [has known issues](https://rstudio.github.io/packrat/limitations.html). The RAP community has noted in particular that it has a problem compiling older package versions on Windows. [Join the discussion for more information](https://github.com/ukgovdatascience/rap_companion/issues/86). 
 
-1. Activate 'packrat mode' in your project folder with `init()`, which records and snapshots the packages you've called in your scripts
-1. Install new packages as usual, except they're now saved to a _private package repository_ within the project, rather than your local machine
-1. By default, regular snapshots are taken to record the state of dependencies, but you can force one with `snapshot()`
-1. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library created on the collaborator's machine
+[A `packrat` walkthrough is available](https://rstudio.github.io/packrat/walkthrough.html), but the basic process is:
 
-[The `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the [Microsoft R Application Network (MRAN)](https://mran.microsoft.com/), which is a daily snapshot of [CRAN](https://cran.r-project.org/). Note that this doesn't permit control of packages that are hosted anywhere other than CRAN, such as Bioconductor or GitHub, and relies on Microsoft continuing to snapshot and store CRAN copies in MRAN.
+1. Activate 'packrat mode' in your project folder with `init()`, which records and snapshots the packages you've called in your scripts.
+1. Install new packages as usual, except they're now saved to a _private package repository_ within the project, rather than your local machine.
+1. By default, regular snapshots are taken to record the state of dependencies, but you can force one with `snapshot()`.
+1. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library created on the collaborator's machine.
 
-Another option is `jetpack`, which is different to `packrat` because it uses a DESCRIPTION file to list your dependencies. [DESCRIPTION files are used in package development](http://r-pkgs.had.co.nz/description.html) to store information, including that package's dependencies. This package claims to be lightweight and can be run from the command line.
+As for other options, [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the [Microsoft R Application Network (MRAN)](https://mran.microsoft.com/), which is a daily snapshot of [CRAN](https://cran.r-project.org/). Note that this doesn't permit control of packages that are hosted anywhere other than CRAN, such as Bioconductor or GitHub, and relies on Microsoft continuing to snapshot and store CRAN copies in MRAN.
+
+Another option is `jetpack`, which is different to `packrat` because it uses a DESCRIPTION file to list your dependencies. [DESCRIPTION files are used in package development](http://r-pkgs.had.co.nz/description.html) to store information, including that package's dependencies. This is a lightweight option and can be run from the command line.
 
 Paid options also exist, but are obviously less accessible and require maintenance. One example is [RStudio's Package Manager](https://www.rstudio.com/products/package-manager/).
 
@@ -157,8 +153,8 @@ This will download the packages one by one into the virtual environment in their
 Good package management deals with one of the major problems of dependency hell. But the problem is bigger. Collaborators could still encounter errors if they: 
 
 * try to run your code in a later version of the language you used during development
-* use a different or updated Integrated Development Environment (IDE, like RStudio or Jupyter Notebooks)
-* try to re-run the analysis on a different system, like if you try to run code on a Linux machine but the original was built on a Microsoft machine
+* use a different or updated [Integrated Development Environment](https://en.wikipedia.org/wiki/Integrated_development_environment) (IDE, like RStudio or Jupyter Notebooks)
+* try to re-run the analysis on a different system, like if they try to run code on a Linux machine but the original was built on a Microsoft machine
 
 What you really want to do is create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the analysis under consistent conditions, regardless of who you are and what equipment you're using.
 
@@ -189,7 +185,3 @@ You don't have to build everything from scratch. [Docker hub](https://hub.docker
 As well as rocker, R users can set up Docker from within an interactive R session: [the `containerit` package](https://o2r.info/containerit/index.html) lets you create a dockerfile given the current state of your session. This simplifies the process a great deal.
 
 R users can also read [Docker for the useR](https://github.com/noamross/nyhackr-docker-talk) by Noam Ross and [an introduction to Docker for R users](https://colinfay.me/docker-r-reproducibility/) by Colin Fay.
-
-[^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.
-[^pip-pin]: These should be 'pinned' meaning that they're in the form `packageName==1.3.2` rather than `packageName>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.
-[^save-session]: With something like `writeLines(capture.output(sessionInfo()), "sessionInfo.txt")` within R and `pip freeze > requirements.txt` in the shell for Python.

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -1,8 +1,132 @@
 # Dependency management {#dep}
 
-> If you want your code to be reproducible in the long-run (i.e. so you can come back to run it next month or next year), you’ll need to track the versions of the packages that your code uses. A rigorous approach is to use packrat, http://rstudio.github.io/packrat/, which store packages in your project directory, or checkpoint, https://github.com/RevolutionAnalytics/checkpoint, which will reinstall packages available on a specified date. A quick and dirty hack is to include a chunk that runs sessionInfo() — that won’t you let easily recreate your packages as they are today, but at least you’ll know what they were. 
-- Hadley Wickham, R for Data Science
+## The trouble with dependencies
 
-One of the problems with working with open source software is that it is quite easy to fall into a trap called ‘[dependency hell](https://en.wikipedia.org/wiki/Dependency_hell)’. Essentially, this occurs when the software we write depends on open source packages, which depend on other open source packages, which can depend on other packages, and on, and on.
+### Scheduled releases
 
-All these packages may be written by many different people, and are updated at vastly different timescales. If we fail to take account of this, then we are likely to fail at the first hurdle of reproducibility, and we may find that in a year’s time we are no longer able to reproduce the work that we previously did - or at least not without a lot of trouble. There are several ways we might get on top of this problem, but in this project we opted for using [packrat](https://rstudio.github.io/packrat/), which creates a cache of all the R packages used in the project which is then version controlled on GitHub. Matt Upson has [blogged about this previously](http://www.machinegurning.com/rstats/latex-phd/) in the context of writing academic works.
+Most statistical publications are updated on a scheduled basis when new data become available. You can see this on the [statistics release calendar on GOV.UK](https://www.gov.uk/government/statistics/announcements).
+
+Let's say you've used a RAP approach to adhere to the principles laid out in [the Code of Practice for Statistics](https://www.statisticsauthority.gov.uk/code-of-practice/): you're using [innovation and improvement](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/value/v4-innovation-and-improvement/) to produce automated [orderly releases](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/trustworthiness/t3-orderly-release/) with [sound methods](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/quality/q2-sound-methods/) and [assured quality](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/quality/q3-assured-quality/). 
+
+Great. This means you have what you need to reproduce the publication when it's time for the next release. What could possibly go wrong?
+
+### Software changes
+
+A major problem is that you have _dependencies_ on other people's code. For example, you've probably imported packages or modules to perform analyses or create plots. This is powerful and useful, but the maintainers of that code can change it at any time. This means the software you used to produce your last release may have been updated.
+
+This may not always be an issue. Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. 
+
+For example, a package maintainer could have updated the way a function works or could have removed it entirely, resulting in a _breaking change_.
+
+At best, your code won't run and you'll get a helpful error message. At worst, your code will execute but an impercetible error may have introduced. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
+
+If you don't have a way to manage this problem then your workflow isnt truly reproducible. You could run the same code now and in a year's time and the output could be different.
+
+The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this?
+
+## Strategies
+
+There's a number of ways to protect yourself from dependency issues. Some are simpler and less automated, others are more complex and resolve the problem by improving reproducibility in general. 
+
+RAP is language and tool-agnostic and so this section provides some ideas that you might consider.
+
+### Record version numbers
+
+You need to know the version number of the software you were using when you ran your analysis.
+
+One simple way to do this would be to record the packages and their version numbers. Yes, you could literally inspect every package, but there are functions that allow you to do this automatically.
+
+You could use `sessionInfo()` to do this in R.[^sessionInfo]
+
+```
+sessionInfo()
+```
+```
+## R version 3.5.1 (2018-07-02)
+## Platform: x86_64-apple-darwin15.6.0 (64-bit)
+## Running under: macOS High Sierra 10.13.6
+## 
+## Matrix products: default
+## BLAS: /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
+## LAPACK: /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libRlapack.dylib
+## 
+## locale:
+## [1] en_GB.UTF-8/en_GB.UTF-8/en_GB.UTF-8/C/en_GB.UTF-8/en_GB.UTF-8
+## 
+## attached base packages:
+## [1] stats     graphics  grDevices utils     datasets  methods   base     
+## 
+## other attached packages:
+## [1] packrat_0.4.8-1
+## 
+## loaded via a namespace (and not attached):
+##  [1] bookdown_0.7      Rcpp_1.0.0        later_0.7.5      
+##  [4] digest_0.6.18     mime_0.6          R6_2.3.0         
+##  [7] magrittr_1.5      evaluate_0.11     xaringan_0.8     
+## [10] stringi_1.2.4     promises_1.0.1    rstudioapi_0.8   
+## [13] rmarkdown_1.11    tools_3.5.1       servr_0.10       
+## [16] stringr_1.3.1     httpuv_1.4.5      xfun_0.3         
+## [19] yaml_2.2.0        rsconnect_0.8.10  compiler_3.5.1   
+## [22] htmltools_0.3.6   knitr_1.21        highlight_0.4.7.2
+```
+
+For Python you can use `pip freeze` in a bash script to achieve a similar thing.
+
+```
+pip freeze
+```
+```
+## alabaster==0.7.10
+## anaconda-client==1.6.14
+## anaconda-navigator==1.8.7
+## anaconda-project==0.8.2
+## appnope==0.1.0
+## appscript==1.0.1
+## argcomplete==1.9.4
+## asn1crypto==0.24.0
+## astroid==1.6.3
+## astropy==3.0.2
+## atomicwrites==1.2.1
+## attrs==18.2.0
+## awscli==1.16.31
+...
+```
+
+Analysts working on the publication's code in future could look at the version numbers and ensure they download that version rather than the latest.
+
+This approach is simple but isn't ideal. It:
+
+* is tedious to do this by hand for each package
+* could be difficult to get hold of earlier versions
+* isn't reproducible because the step between reading the version numbers and installing them isn't automated
+* isn't _isolated_, meaning that you'll overwrite any current versions on your machine globally
+
+What's better?
+
+### Environments for dependency management
+
+We could create a separate, isolated environment into which we install dependencies based on our list of packages and version numbers. This allows you to install packages in a repeatable way on a per-project basis without overwriting packages gloablly.
+
+#### Package managers
+
+[The `packrat` package](https://rstudio.github.io/packrat/).
+
+A similar approach is to use [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Revolution Analytics, which is owned by Microsoft. It works like `packrat` but you simply `checkpoint()` your project for a given date. This allows you to call the packages from that date into your workspace. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/).
+
+#### Virtual environments in Python
+
+[`Pipenv` and `virtualenv`](https://docs.python-guide.org/dev/virtualenvs/) plus a requirements.txt file created using `pip freeze`.
+
+## Another problem
+
+What about the version of the analytical software you're using? You may have written the original code in R version 3.4.1 but your computer is currently running R version 3.5.1. This is a similar problem to the issue of packages and modules: the functioning of code is also dependent on changes to the scripting tool itself.
+
+You need to think bigger than an isolated environment for package installation. We need some kind of isolated environment for both the packages _and_ the tools. And why stop there? We could put our functions, tests and data in there too.
+
+A 'container' for our publication is a good idea. We can isolate all the components of our RAP publication and make it even more portable.
+
+### Docker
+
+One way of doing this is to use Docker.
+
+[^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -10,17 +10,17 @@ Let's say you've used a RAP approach to adhere to the principles laid out in [th
 
 Great. This means you have what you need to reproduce the publication when it's time for the next release. What could possibly go wrong?
 
-### Software changes
+### Dependency hell
 
 A major problem is that you have _dependencies_ on other people's code. For example, you've probably imported packages or modules to perform analyses or create plots. This is powerful and useful, but the maintainers of that code can change it at any time. This means the software you used to produce your last release may have been updated.
 
-This may not always be an issue. Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. 
+A maintainer should update the version number of their package when something changes. This could be a simple patch of an earlier version's bug (e.g. version 3.2.7 replaces 3.2.6), through to a major _breaking_ change (e.g. version 3.2.6 is update to version 4.0.0).
 
-For example, a package maintainer could have updated the way a function works or could have removed it entirely, resulting in a _breaking change_.
+This may not always be an issue. Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. 
 
 At best, your code won't run and you'll get a helpful error message. At worst, your code will execute but an impercetible error may have introduced. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
 
-If you don't have a way to manage this problem then your workflow isnt truly reproducible. You could run the same code now and in a year's time and the output could be different.
+If you don't have a way to manage this problem then your workflow isn't truly reproducible. You could run the same code now and in a year's time and the output could be different.
 
 The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this?
 
@@ -28,17 +28,15 @@ The bottom line: your publication is dependent on particular software _and_ its 
 
 There's a number of ways to protect yourself from dependency issues. Some are simpler and less automated, others are more complex and resolve the problem by improving reproducibility in general. 
 
-RAP is language and tool-agnostic and so this section provides some ideas that you might consider.
+RAP is language and tool-agnostic and so this section provides some ideas that you might consider. Other options are available and you should consider what is best for you based on your infrastructure and the technical knowledge of you, your team and anyone who might work on the project in future.
 
 ### Record version numbers
-
-You need to know the version number of the software you were using when you ran your analysis.
 
 One simple way to do this would be to record the packages and their version numbers. Yes, you could literally inspect every package, but there are functions that allow you to do this automatically.
 
 You could use `sessionInfo()` to do this in R.[^sessionInfo]
 
-```
+```{r, eval=FALSE}
 sessionInfo()
 ```
 ```
@@ -70,9 +68,9 @@ sessionInfo()
 ## [22] htmltools_0.3.6   knitr_1.21        highlight_0.4.7.2
 ```
 
-For Python you can use `pip freeze` in a bash script to achieve a similar thing.
+For Python you can use `pip freeze` in a shell script to achieve a similar thing.[^pip-pin]
 
-```
+```{bash, eval=FALSE}
 pip freeze
 ```
 ```
@@ -97,7 +95,6 @@ Analysts working on the publication's code in future could look at the version n
 This approach is simple but isn't ideal. It:
 
 * is tedious to do this by hand for each package
-* could be difficult to get hold of earlier versions
 * isn't reproducible because the step between reading the version numbers and installing them isn't automated
 * isn't _isolated_, meaning that you'll overwrite any current versions on your machine globally
 
@@ -105,17 +102,47 @@ What's better?
 
 ### Environments for dependency management
 
-We could create a separate, isolated environment into which we install dependencies based on our list of packages and version numbers. This allows you to install packages in a repeatable way on a per-project basis without overwriting packages gloablly.
+Ideally we want to _automate_ the process of recording packages and their version numbers and have them installed in an _isolated environment_ that's specific to our project. Doing this makes the project more _portable_ -- you could run it easily from another machine that's configured differently to your own -- and therfore more _reproducible_ by others.
 
-#### Package managers
+#### Package managers in R
 
-[The `packrat` package](https://rstudio.github.io/packrat/).
+A popular choice in R is [the `packrat` package](https://rstudio.github.io/packrat/). When working in your project's repository, you can call `packrat::init()` to turn on 'Packrat mode' for your project. This means your package dependencies will now be stored in a _private package library_ that's isolated within the project folder. In this mode, any packages you install within your project are stored in the private library. Regular 'snapshots' are taken to record the state of dependencies.
 
-A similar approach is to use [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Revolution Analytics, which is owned by Microsoft. It works like `packrat` but you simply `checkpoint()` your project for a given date. This allows you to call the packages from that date into your workspace. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/).
+A similar tool is [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics. It works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/). One caveat is that you're dependent on MRAN to continue snapshotting CRAN and for it to continue to be maintained.
 
 #### Virtual environments in Python
 
-[`Pipenv` and `virtualenv`](https://docs.python-guide.org/dev/virtualenvs/) plus a requirements.txt file created using `pip freeze`.
+Setting up an isolated environment -- also called a virtual environment -- is also an option in Python with things like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
+
+We can set up a virtual environment in our project folder, install any modules we need and then record them in a file for people to use in future. A shell script to do this might be:
+
+```{bash, eval=FALSE}
+# 1. Navigate to your project folder
+cd path/to/project/file
+
+# 2. Create a virtual environment (a folder in your home directory)
+virtualenv venv
+
+# 3. 'Activate' the virtual environment
+source venv/bin/activate
+
+# 4. Install the modules you need
+pip install <name>
+
+# 5. Record the package-version list to a file in your home directory
+pip freeze > requirements.txt
+
+# 6. Deactivate the virtual environment when you're done
+deactivate
+```
+
+When another user downloads your version-controlled project folder, the requirements.txt file will be there. Now they can create a virtual environment on their machine following steps 1 to 3 above, but rather than `pip install <module>` they can install based on the instructions from the requirements.txt file:
+
+```{bash, eval=FALSE}
+pip install -r requirements.txt
+```
+
+This will download the modules one by one into the virtual environment.
 
 ## Another problem
 
@@ -130,3 +157,4 @@ A 'container' for our publication is a good idea. We can isolate all the compone
 One way of doing this is to use Docker.
 
 [^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.
+[^pip-pin]: These should be 'pinned' meaning that they're in the form `module==1.3.2` rather than `module>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -193,7 +193,7 @@ virtualenv venv
 source venv/bin/activate
 ```
 
-You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2.
+You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2. Lt's continue.
 
 ```{bash, eval=FALSE}
 # 4. Install the modules you need
@@ -225,6 +225,30 @@ A 'container' for our publication is a good idea. We can isolate all the compone
 ### Docker
 
 One way of doing this is to use Docker.
+
+
+General
+
+* [GOV.UK on software dependencies](https://www.gov.uk/service-manual/technology/managing-software-dependencies)
+* [Docker for beginners](https://docker-curriculum.com/) by Docker
+* [Using containers to deliver our data projects](https://dwpdigital.blog.gov.uk/2018/05/18/using-containers-to-deliver-our-data-projects/), a DWP blog by Phil Chapman, and [a more in-depth personal blog](https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/) 
+
+R-focused
+
+* [An introduction to Docker for R users](https://colinfay.me/docker-r-reproducibility/) by Colin Fay
+* [Docker for the useR](https://github.com/noamross/nyhackr-docker-talk) by Noam Ross
+* [Production-ready R: Getting started with R and docker](https://www.youtube.com/watch?v=lfG8cTqRRNA) by Elizabeth Stark at UseR!2018 (YouTube)
+* [Applications with R and Docker](https://www.youtube.com/watch?v=JOIKy_89c-o) by Scott Came at UseR!2018 (YouTube)
+* [Rocker](https://hub.docker.com/u/rocker) on Docker Hub
+* [containerit](https://o2r.info/containerit/) packagedown site
+* [rOpenSci labs tutorial](http://ropenscilabs.github.io/r-docker-tutorial/)
+
+Papers
+
+* [An Introduction to Rocker: Docker Containers for R](https://journal.r-project.org/archive/2017/RJ-2017-065/RJ-2017-065.pdf) in the R Journal, by Carl Boettiger and Dirk Eddelbuettel
+* [Reproducibility of computational workflows is automated using continuous analysis](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6103790/) in Nature Biotechnology
+Google Scholar search results
+
 
 [^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.
 [^pip-pin]: These should be 'pinned' meaning that they're in the form `module==1.3.2` rather than `module>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -18,7 +18,7 @@ Most statistical publications are [updated on a scheduled basis](https://www.gov
 
 It's possible that you'll get some errors when you reuse your RAP project code for the next update, even if everything worked perfectly last time. Why? The maintainers of your dependencies may have changed the code and it no longer works as you expect.
 
-Changes might not impact your publication. If not, the best case is that you'll get a helpful error message. At worst, your code will execute with an impercetible but impactful error. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
+Changes might not impact your publication. If changes do have an impact, the best case is that you'll get a helpful error message. At worst, your code will execute with an impercetible but impactful error. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
 
 The problem is compounded if your dependencies depend on other dependencies, or if two of your dependencies require conflicting versions of a third dependency. You could get stuck in so-called [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
@@ -113,96 +113,26 @@ Ideally we want to automate the process of recording packages and their version 
 
 #### Package managers in R
 
-A popular choice for automated package management in R is [the `packrat` package](https://rstudio.github.io/packrat/). The Packrat developers have created [a walkthrough on their website](https://rstudio.github.io/packrat/walkthrough.html).
+There is currently no consensus approach for package management in R. Below are a few options, but this is a non-exhaustive list.
 
-You need only run one line to activate 'Packrat mode' for your project. 
+[The `packrat` package](https://rstudio.github.io/packrat/) is often referred to, but [has its issues](https://rstudio.github.io/packrat/limitations.html). A [walkthrough is available](https://rstudio.github.io/packrat/walkthrough.html), but the basic process is:
 
-```{r, eval=FALSE}
-packrat::init("~/projects/rap-project")
-```
-```
-Adding these packages to packrat:
-            _         
-    packrat   0.2.0.128
+1. Activate 'packrat mode' in your project folder with `init()`, which records and snapshots the packages you've called in your scripts
+1. Install new packages as usual, except they're now saved to a _private package repository_ within the project, rather than your local machine
+1. By default, regular snapshots are taken to record the state of dependencies, but you can force one with `snapshot()`
+1. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library created on the collaborator's machine
 
-Fetching sources for packrat (0.2.0.128) ... OK (GitHub)
-Snapshot written to '/Users/matt/projects/rap-project/packrat/packrat.lock'
-Installing packrat (0.2.0.128) ... OK (built source)
-init complete!
-Packrat mode on. Using library in directory:
-- "~/projects/rap-project/packrat/lib" 
-```
+[The `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the [Microsoft R Application Network (MRAN)](https://mran.microsoft.com/), which is a daily snapshot of [CRAN](https://cran.r-project.org/). Note that this doesn't permit control of packages that are hosted anywhere other than CRAN, such as Bioconductor or GitHub, and relies on Microsoft continuing to snapshot and store CRAN copies in MRAN.
 
-What happened here? Packrat:
+Another option is `jetpack`, which is different to `packrat` because it uses a DESCRIPTION file to list your dependencies. [DESCRIPTION files are used in package development](http://r-pkgs.had.co.nz/description.html) to store information, including that package's dependencies. This package claims to be lightweight and can be run from the command line.
 
-* was initiated within our project folder only
-* found a specific version of a package (`packrat` itself!) in use within the project
-* downloaded the package it found to a _private package library_, a new folder isolated within the project for storing packages
-* recorded a snapshot of the current state of the dependencies
-
-With Packrat mode on, any newly-downloaded packages are saved _within_ your project in the private library. By default, regular snapshots are taken to record the state of dependencies. You can also force this with `packrat::snapshot()`. 
-
-```{r, eval=FALSE}
-packrat::snapshot()
-```
-```
-Adding these packages to packrat:
-             _       
-    plyr       1.8.1 
-    Rcpp       0.11.2
-    reshape2   1.4   
-    stringr    0.6.2 
-
-Fetching sources for plyr (1.8.1) ... OK (CRAN current)
-Fetching sources for Rcpp (0.11.2) ... OK (CRAN current)
-Fetching sources for reshape2 (1.4) ... OK (CRAN current)
-Fetching sources for stringr (0.6.2) ... OK (CRAN current)
-Snapshot written to '/Users/matt/projects/rap-project/packrat/packrat.lock'
-```
-
-This shows a user-initiated snapshot after installing a few packages (`plyr`, `Rcpp`, `reshape2` and `stringr`). You can see that Packrat fetches the sources and records a snapshot.
-
-So far this looks like an automated version of recording the output of 'sessionInfo()` with a special private library so you're only using specific package versions for your project. When you run this again in future, you'll have the exact versions you need to recreate the analysis. 
-
-Great, but what if a collaborator downloads the package? This is where we see the power of the snapshot. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library, created on the collaborator's machine.
-
-```
-Packrat is not installed in the local library -- attempting to bootstrap an installation...
-> Installing packrat into project private library:
-- '/Users/matt/projects/rap-project/packrat/lib/x86_64-apple-darwin13.1.0/3.2.0'
-* installing *source* package ‘packrat’ ...
-** R
-** inst
-** preparing package for lazy loading
-** help
-*** installing help indices
-** building package indices
-** testing if installed package can be loaded
-* DONE (packrat)
-> Attaching packrat
-> Restoring library
-Installing plyr (1.8.1) ... OK (built source)
-Installing Rcpp (0.11.2) ... OK (built source)
-Installing reshape2 (1.4) ... OK (built source)
-Installing stringr (0.6.2) ... OK (built source)
-> Packrat bootstrap successfully completed. Entering packrat mode...
-Packrat mode on. Using library in directory:
-- "~/projects/babynames/packrat/lib"
-```
-
-Note that [there are some caveats](https://rstudio.github.io/packrat/limitations.html) to using Packrat.
-
-A similar tool to `packrat` is [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics. It works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/). One caveat is that you're dependent on MRAN to continue snapshotting CRAN and for it to continue to be maintained.
-
-
+Paid options also exist, but are obviously less accessible and require maintenance. One example is [RStudio's Package Manager](https://www.rstudio.com/products/package-manager/).
 
 #### Virtual environments in Python
 
-In Python we can create an isolated environment for our project and load packages into it.
+In Python we can easily create an isolated environment for our project and load packages into it. This is possible with tools like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
 
-This is possible with tools like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
-
-You can set up a virtual environment in your project folder, activate it, install any packages you need and then record them in a file for use in future. Install `virtualenv` and navigate to your project's home folder. A shell script to do this might be:
+You can set up a virtual environment in your project folder, activate it, install any packages you need and then record them in a file for use in future. One way to do this is with `virtualenv`. After installation and having navigated to your project's home folder, you can follow something like this from the command line:
 
 ```{bash, eval=FALSE}
 virtualenv venv  # create virtual environment folder

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -2,51 +2,46 @@
 
 _This section is in development. Please [contribute to the discussion](https://github.com/ukgovdatascience/rap_companion/issues/89)._
 
-## The trouble with dependencies
+## Other people's code
 
-This section is about the code in your project that was written by other people, like R or Python packages. Management of these dependencies goes hand-in-hand with reproducibility. You can't recreate your outputs or update them if there are problems with your dependencies.
+You're likely to make use of other people's code when you develop your RAP project. Maybe you've imported packages to perform a statistical test, for example. These dependencies can be extremely helpful. They can:
 
-A basic understanding of the command line and R or Python are ideal.
+* prevent you from recreating code that already exists
+* save you time trying to solve a problem and optimise its solution
+* give you access to code and solutions from experts in the field
+* help to reduce the size of your scripts and make them more human-readable
+* limit the need for you to update and fix problems yourself
 
-### Scheduled releases
+### Limitations
 
-Most statistical publications are updated on a scheduled basis when new data become available. You can see this on the [statistics release calendar on GOV.UK](https://www.gov.uk/government/statistics/announcements) and it's enshrined in [the Statistics Code of Practice](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/trustworthiness/t3-orderly-release/).
+Most statistical publications are [updated on a scheduled basis](https://www.gov.uk/government/statistics/announcements) when new data become available.
 
-Let's say you've used a RAP approach for your publication so that minimal effort is required to reproduce your outputs with the latest data. When the day comes to re-run your code to produce the latest update, you get a cryptic error. Hang on, this worked three months ago. What has gone wrong?
+It's possible that you'll get some errors when you reuse your RAP project code for the next update, even if everything worked perfectly last time. Why? The maintainers of your dependencies may have changed the code and it no longer works as you expect.
 
-### Dependency hell
+Changes might not impact your publication. If not, the best case is that you'll get a helpful error message. At worst, your code will execute with an impercetible but impactful error. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
 
-Using other people's code in your code can take a lot of weight off your shoulders: these _dependencies_ prevent you from having to implement tricky code problems yourself and limit the need for you update and fix problems. For example, you've probably imported packages to prevent you writing something from scratch, like the implementation of a statistical test. 
-
-This is a powerful and useful concept, but the maintainers of the code _can change it at any time_. This means the software you used to produce your last release may have been updated and no longer works as you expect. Oh, and it's likely that your dependencies have dependencies of their own. You can get in a tangled mess quite easily.
-
-Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. At best, your code won't run and you'll get a helpful error message. At worst, your code will execute but an impercetible but impactful error may have been introduced. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
+The problem is compounded if your dependencies depend on other dependencies, or if two of your dependencies require conflicting versions of a third dependency. You could get stuck in so-called [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
 The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this?
 
-## Strategies
+### Think lightweight
 
-There's a number of ways to protect yourself from dependency hell. Some are simpler and less automated, others are more complex and resolve the problem by improving reproducibility in general. 
-
-RAP is language and tool-agnostic and so this section provides some ideas that you might consider. Other options are available and you should consider what is best for you based on your infrastructure and the technical knowledge of your team and anyone who might work on the project in future.
-
-### Minimise your dependencies
-
-The convenience and ubiquity of freely-available software packages mean that it's unlikely that you'll have zero dependencies in your code. Rather, the goal should be to:
-
-* minimise the number of dependencies (do you have three packages for string manipulation when one would do?)
-* restrict yourself to stable packages (try to avoid experimental packages or ones that haven't been updated in a long time)
-* bear in mind any replacement packages (you should have an alternative if your dependency is no longer maintained and develops bugs)
-
-This is enshrined in [the tinyverse philosophy of dependency management](http://www.tinyverse.org/)  as:
+First, think about what you can do to reduce the chance of problems. To put it succinctly, [the tinyverse philosophy of dependency management](http://www.tinyverse.org/) suggests that:
 
 >Lightweight is the right weight
 
-and
+To achieve this you could:
 
->Every dependency you add to your project is an invitation to break your project
+* minimise the number of dependencies and remove redundancy where possible
+* avoid depending on packages that in turn have many dependencies
+* restrict yourself to 'stable' packages for which recent changes were restricted to minor updates and bug-fixes
+* review regularly your dependencies to establish if better alternatives exist 
 
-You have been warned!
+### Record the packages and versions
+
+It's not enough to simply minimise your dependencies. You need to think about how this impacts the reproducibility of your project. To ensure that your scripts are executed in the same way next time, you need to record the packages and their versions in some way. Then you or a colleague can recreate the environment in which the outputs were produced the first time round.
+
+## Approaches
 
 ### Version numbers
 
@@ -229,7 +224,7 @@ This will download the packages one by one into the virtual environment in their
 
 ### Theory
 
-Good package management deals with one of the major problems of dependency hell. But the problem is bigger.Collaborators could still encounter errors if they: 
+Good package management deals with one of the major problems of dependency hell. But the problem is bigger. Collaborators could still encounter errors if they: 
 
 * try to run your code in a later version of the language you used during development
 * use a different or updated Integrated Development Environment (IDE, like RStudio or Jupyter Notebooks)

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -4,41 +4,55 @@ _This section is in development. Please [contribute to the discussion](https://g
 
 ## The trouble with dependencies
 
-This section is about managing code written by other people, such as R or Python packages. It's important to consider how you're going to manage this code that your publication is _dependent_ on. Methods for doing this overlap with methods for reproducibility in general.
+This section is about the code in your project that was written by other people, like R or Python packages. Management of these dependencies goes hand-in-hand with reproducibility. You can't recreate your outputs or update them if there are problems with your dependencies.
 
 ### Scheduled releases
 
-Most statistical publications are updated on a scheduled basis when new data become available. You can see this on the [statistics release calendar on GOV.UK](https://www.gov.uk/government/statistics/announcements).
+Most statistical publications are updated on a scheduled basis when new data become available. You can see this on the [statistics release calendar on GOV.UK](https://www.gov.uk/government/statistics/announcements) and it's enshrined in [the Statistics Code of Practice](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/trustworthiness/t3-orderly-release/).
 
-Let's say you've used a RAP approach to adhere to the principles laid out in [the Code of Practice for Statistics](https://www.statisticsauthority.gov.uk/code-of-practice/): you're using [innovation and improvement](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/value/v4-innovation-and-improvement/) to produce automated [orderly releases](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/trustworthiness/t3-orderly-release/) with [sound methods](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/quality/q2-sound-methods/) and [assured quality](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/quality/q3-assured-quality/). 
-
-Great. This means you have what you need to reproduce the publication when it's time for the next release. What could possibly go wrong?
+Let's say you've used a RAP approach for your publication so that minimal effort is required to reproduce your outputs with the latest data. When the day comes to re-run your code to produce the latest update, you get a cryptic error. Hang on, this worked three months ago. What has gone wrong?
 
 ### Dependency hell
 
-A major problem is that you have _dependencies_ on other people's code. For example, you've probably imported packages to perform analyses or create plots. This is powerful and useful, but the maintainers of that code can change it at any time. This means the software you used to produce your last release may have been updated.
+Using other people's code in your code can take a lot of weight off your shoulders: these _dependencies_ prevent you from having to implement tricky code problems yourself and limit the need for you update and fix problems. For example, you've probably imported packages to prevent you writing something from scratch, like the implementation of a statistical test. 
 
-A maintainer should update the version number of their package when something changes. This could be a simple patch of an earlier version's bug (e.g. version 3.2.7 replaces 3.2.6), through to a major _breaking_ change (e.g. version 3.2.6 is update to version 4.0.0).
+This is a powerful and useful concept, but the maintainers of the code _can change it at any time_. This means the software you used to produce your last release may have been updated and no longer works as you expect. Oh, and it's likely that your dependencies have dependencies of their own. You can get in a tangled mess quite easily.
 
-This may not always be an issue. Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. 
-
-At best, your code won't run and you'll get a helpful error message. At worst, your code will execute but an impercetible error may have introduced. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
-
-If you don't have a way to manage this problem then your workflow isn't truly reproducible. You could run the same code now and in a year's time and the output could be different.
+Changes may be minimal and might not impact your publication. But a newer version may not behave in the way you expect. At best, your code won't run and you'll get a helpful error message. At worst, your code will execute but an impercetible but impactful error may have been introduced. Maybe a rounding function now rounds to the nearest 10 instead of the nearest 1000.
 
 The bottom line: your publication is dependent on particular software _and_ its state at a given time. How can you deal with this?
 
 ## Strategies
 
-There's a number of ways to protect yourself from dependency issues. Some are simpler and less automated, others are more complex and resolve the problem by improving reproducibility in general. 
+There's a number of ways to protect yourself from dependency hell. Some are simpler and less automated, others are more complex and resolve the problem by improving reproducibility in general. 
 
-RAP is language and tool-agnostic and so this section provides some ideas that you might consider. Other options are available and you should consider what is best for you based on your infrastructure and the technical knowledge of you, your team and anyone who might work on the project in future.
+RAP is language and tool-agnostic and so this section provides some ideas that you might consider. Other options are available and you should consider what is best for you based on your infrastructure and the technical knowledge of your team and anyone who might work on the project in future.
+
+### Minimise your dependencies
+
+The convenience and ubiquity of freely-available software packages mean that it's unlikely that you'll have zero dependencies in your code. Rather, the goal should be to:
+
+* minimise the number of dependencies (do you have three packages for string manipulation when one would do?)
+* restrict yourself to stable packages (try to avoid experimental packages or ones that haven't been updated in a long time)
+* bear in mind any replacement packages (you should have an alternative if your dependency is no longer maintained and develops bugs)
+
+This is enshrined in [the tinyverse philosophy of dependency management](http://www.tinyverse.org/)  as:
+
+>Lightweight is the right weight
+
+and
+
+>Every dependency you add to your project is an invitation to break your project
+
+You have been warned!
 
 ### Version numbers
 
-We can record each package and the version we used during the analysis.
+Maintainers signal updates by increasing the version number of their software. This could be a simple patch of an earlier version's bug (e.g. version 3.2.7 replaces 3.2.6), or perhaps a major _breaking_ change (e.g. version 3.2.6 is update to version 4.0.0).
 
-For example, you could use `sessionInfo()` in R.[^sessionInfo]
+There are many ways to record each of the packages used in our analysis and their version numbers.
+
+For example, in R you could use the `sessionInfo()` package.[^sessionInfo] This prints details about the current state of the working environment, including the packages and version numbers. 
 
 ```{r, eval=FALSE}
 sessionInfo()
@@ -72,7 +86,7 @@ sessionInfo()
 ## [22] htmltools_0.3.6   knitr_1.21        highlight_0.4.7.2
 ```
 
-You can achieve a similar thing in Python with `pip freeze` in a shell script.[^pip-pin]
+You can achieve a similar thing for Python with `pip freeze` in a shell script.[^pip-pin] Again, this provides a list of the packages available in the current environment and their version numbers.
 
 ```{bash, eval=FALSE}
 pip freeze
@@ -90,21 +104,21 @@ pip freeze
 ...
 ```
 
-But simply saving this information[^save-session] isn't good dependency control. It:
+But simply saving this information[^save-session] in your project folder isn't good dependency control. It:
 
-* would be tedious for analysts to download each recorded package version one-by-one
-* records _every_ package and its version _on your whole system_; not just the ones relevant to your project
+* would be tedious for analysts to read these reports and download each recorded package version one-by-one
+* records _every_ package and its version _on your whole system_, not just the ones relevant to your project
 * isn't a reproducible or automated process
 
 ### Environments for dependency management
 
-Ideally we want to _automate_ the process of recording packages and their version numbers and have them installed in an _isolated environment_ that's specific to our project. Doing this makes the project more _portable_ -- you could run it easily from another machine that's configured differently to your own -- and therfore it would be more _reproducible_.
+Ideally we want to automate the process of recording packages and their version numbers and have them installed in an isolated environment that's specific to our project. Doing this makes the project more portable -- you could run it easily from another machine that's configured differently to your own -- and it would therefore be more reproducible.
 
 #### Package managers in R
 
-A popular choice in R is [the `packrat` package](https://rstudio.github.io/packrat/).
+A popular choice for automated package management in R is [the `packrat` package](https://rstudio.github.io/packrat/). The Packrat developers have created [a walkthrough on their website](https://rstudio.github.io/packrat/walkthrough.html).
 
-In this example from [Packrat's walkthrough](https://rstudio.github.io/packrat/walkthrough.html) you can see that calling `packrat::init()` in your project's repository causes 'Packrat mode' to activate for that project.
+You need only run one line to activate 'Packrat mode' for your project. 
 
 ```{r, eval=FALSE}
 packrat::init("~/projects/rap-project")
@@ -124,11 +138,12 @@ Packrat mode on. Using library in directory:
 
 What happened here? Packrat:
 
-* found a specific version of package in use in the project (itself!)
-* downloaded it to a _private package library_, a new folder within the project for storing packages isolated within that project
-* recorded a snapshot (a bit like saving `sessionInfo()`)
+* was initiated within our project folder only
+* found a specific version of a package (`packrat` itself!) in use within the project
+* downloaded the package it found to a _private package library_, a new folder isolated within the project for storing packages
+* recorded a snapshot of the current state of the dependencies
 
-With Packrat mode on, any newly-downloaded packages are saved _within_ your project in the private library. By default, regular snapshots are taken to record the state of dependencies. You can force this with `packrat::snapshot()`. [This example](https://rstudio.github.io/packrat/walkthrough.html) shows a user-initiated snapshot after installing a few packages (`plyr`, `Rcpp`, `reshape2` and `stringr`). You can see that Packrat fetcches the sources and records a snapshot.
+With Packrat mode on, any newly-downloaded packages are saved _within_ your project in the private library. By default, regular snapshots are taken to record the state of dependencies. You can also force this with `packrat::snapshot()`. 
 
 ```{r, eval=FALSE}
 packrat::snapshot()
@@ -148,9 +163,11 @@ Fetching sources for stringr (0.6.2) ... OK (CRAN current)
 Snapshot written to '/Users/matt/projects/rap-project/packrat/packrat.lock'
 ```
 
-So far this loooks like an automated version of recording the output of 'sessionInfo()` with a special private library so you're only using specific package versions for your project. When you run this again in future, you'll have the exact versions you need to recreate the analysis. 
+This shows a user-initiated snapshot after installing a few packages (`plyr`, `Rcpp`, `reshape2` and `stringr`). You can see that Packrat fetches the sources and records a snapshot.
 
-Great, but what if a collaborator downloads the package? This is where we see the power of the snapshot. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library. created on that collaborator's machine.
+So far this looks like an automated version of recording the output of 'sessionInfo()` with a special private library so you're only using specific package versions for your project. When you run this again in future, you'll have the exact versions you need to recreate the analysis. 
+
+Great, but what if a collaborator downloads the package? This is where we see the power of the snapshot. When opening the project fresh on a new machine, Packrat automates the process of fetching the packages -- with their recorded version numbers -- and storing them in a private package library, created on the collaborator's machine.
 
 ```
 Packrat is not installed in the local library -- attempting to bootstrap an installation...
@@ -193,7 +210,7 @@ We can set up a virtual environment in our project folder, activate it, install 
 cd ~/projects/rap-project/
 
 # 2. Create a virtual environment folder there
-virtualenv venv
+virtualenv venv  # 'venv' will be the folder name
 
 # 3. 'Activate' the virtual environment
 source venv/bin/activate
@@ -224,23 +241,23 @@ This will download the packages one by one into the virtual environment in their
 
 ### Theory
 
-Storing information about third-party packages is great, but there are still dependency management and reproduciblity issues. Collaborators could still encounter errors if they: 
+Storing information about third-party packages is great, but there are still dependency management and reproducibility issues. Collaborators could still encounter errors if they: 
 
 * try to run your code in an later version of the language you used during development
 * use a different or updated Integrated Development Environment (IDE, like RStudio or Jupyter Notebooks)
 * try to re-run the analysis on a Linux machine but the original was developed on Windows, for example
 
-Fortunately, there are options to deal with this. One is [Docker](https://www.docker.com/), which effectively allows you to create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the anlysis under consistent conditions, regardless of who you are and what equipment you're using.
+Fortunately, there are options to deal with this. One is [Docker](https://www.docker.com/), which effectively allows you to create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the analysis under consistent conditions, regardless of who you are and what equipment you're using.
 
 It works like this:
 
-1. Create a _dockerfile_. This is like a recipe that will build from scratch everything you need for your project to run. It's just a textfile that you can put under version control.
-2. Run the dockerfile to generate a Docker _image_. The image is an instance of the environment and everything you need to recreate your analysis. It's a delicious cake you made following the recipe.
-3. Other people can follow the dockerfile recipe to make their own copies of the delicious image cake. Each running instance of an image is called a _container_.
+1. Create a 'dockerfile'. This is like a plain-text recipe that will build from scratch everything you need for your project to run. It's just a textfile that you can put under version control.
+2. Run the dockerfile to generate a Docker 'image'. The image is an instance of the environment and everything you need to recreate your analysis. It's a delicious cake you made following the recipe.
+3. Other people can follow the dockerfile recipe to make their own copies of the delicious image cake. Each running instance of an image is called a container.
 
 You can learn more about this process by [following the curriculum on Docker's website](https://docker-curriculum.com/). You can also read about the use of Docker [in the Department for Work and Pensions](https://dwpdigital.blog.gov.uk/2018/05/18/using-containers-to-deliver-our-data-projects/) (DWP). Phil Chapman [wrote more about the technical side of this process](https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/).
 
-### Make your life easier
+### Making it easier
 
 You don't have to build everything from scratch. [Docker hub](https://hub.docker.com/) is a big library of pre-prepared container images. For example, the [rocker project on Docker hub](https://hub.docker.com/u/rocker) lists a number of images containing R-specific tools like [rocker/tidyverse](https://hub.docker.com/r/rocker/tidyverse) that contains R, RStudio and [the tidyverse packages](https://tidyverse.tidyverse.org/). You can specify a rocker image in your dockerfile to make your life easier. Learn more about [rOpenSci labs tutorial](http://ropenscilabs.github.io/r-docker-tutorial/)
 

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -6,6 +6,8 @@ _This section is in development. Please [contribute to the discussion](https://g
 
 This section is about the code in your project that was written by other people, like R or Python packages. Management of these dependencies goes hand-in-hand with reproducibility. You can't recreate your outputs or update them if there are problems with your dependencies.
 
+A basic understanding of the command line and R or Python are ideal.
+
 ### Scheduled releases
 
 Most statistical publications are updated on a scheduled basis when new data become available. You can see this on the [statistics release calendar on GOV.UK](https://www.gov.uk/government/statistics/announcements) and it's enshrined in [the Statistics Code of Practice](https://www.statisticsauthority.gov.uk/code-of-practice/the-code/trustworthiness/t3-orderly-release/).
@@ -197,63 +199,61 @@ Note that [there are some caveats](https://rstudio.github.io/packrat/limitations
 
 A similar tool to `packrat` is [the `checkpoint` package](https://github.com/RevolutionAnalytics/checkpoint/wiki) from Microsoft's Revolution Analytics. It works like `packrat` but you simply `checkpoint()` your project for a given _date_. This allows you to call the packages from that date into a private library for that project. It works by fetching the packages from the Microsoft R Application Network (MRAN), which is a daily snapshot of [CRAN](https://cran.r-project.org/). One caveat is that you're dependent on MRAN to continue snapshotting CRAN and for it to continue to be maintained.
 
+
+
 #### Virtual environments in Python
 
 In Python we can create an isolated environment for our project and load packages into it.
 
 This is possible with tools like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
 
-We can set up a virtual environment in our project folder, activate it, install any packages we need and then record them in a file for use in future. A shell script to do this might be:
+You can set up a virtual environment in your project folder, activate it, install any packages you need and then record them in a file for use in future. Install `virtualenv` and navigate to your project's home folder. A shell script to do this might be:
 
 ```{bash, eval=FALSE}
-# 1. Navigate to your project folder
-cd ~/projects/rap-project/
-
-# 2. Create a virtual environment folder there
-virtualenv venv  # 'venv' will be the folder name
-
-# 3. 'Activate' the virtual environment
-source venv/bin/activate
+virtualenv venv  # create virtual environment folder
+source venv/bin/activate  # activate the environment
+pip install packageName  # install packages you need
+pip freeze > requirements.txt  # save package-version list
+deactivate  # deactivate the environment when done
 ```
 
-You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2. Let's continue.
-
-```{bash, eval=FALSE}
-# 4. Install the packages you need, e.g. numpy
-pip install numpy
-
-# 5. Record the package-version list to a file in your home directory
-pip freeze > requirements.txt
-
-# 6. Deactivate the virtual environment when you're done
-deactivate
-```
-
-When another user downloads your version-controlled project folder, the requirements.txt file will be there. Now they can create a virtual environment on their machine following steps 1 to 3 above, but rather than `pip install packageName` for each package they need, they can automate the process by installing everything from the requirements.txt file. From the shell:
+When another user downloads your version-controlled project folder, the requirements.txt file will be there. Now they can create a virtual environment on their machine following steps 1 to 3 above, but rather than `pip install packageName` for each package they need, they can automate the process by installing everything from the requirements.txt file with:
 
 ```{bash, eval=FALSE}
 pip install -r requirements.txt
 ```
 
-This will download the packages one by one into the virtual environment in their copy of the project virtual environment.
+This will download the packages one by one into the virtual environment in their copy of the project virtual environment. Now they'll be using the same packages you were when you developed your project.
 
 ## Containers
 
 ### Theory
 
-Storing information about third-party packages is great, but there are still dependency management and reproducibility issues. Collaborators could still encounter errors if they: 
+Good package management deals with one of the major problems of dependency hell. But the problem is bigger.Collaborators could still encounter errors if they: 
 
-* try to run your code in an later version of the language you used during development
+* try to run your code in a later version of the language you used during development
 * use a different or updated Integrated Development Environment (IDE, like RStudio or Jupyter Notebooks)
-* try to re-run the analysis on a Linux machine but the original was developed on Windows, for example
+* try to re-run the analysis on a different system, like if you try to run code on a Linux machine but the original was built on a Microsoft machine
 
-Fortunately, there are options to deal with this. One is [Docker](https://www.docker.com/), which effectively allows you to create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the analysis under consistent conditions, regardless of who you are and what equipment you're using.
+What you really want to do is create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the analysis under consistent conditions, regardless of who you are and what equipment you're using.
+
+Imagine one of those ubiquitous [shipping containers](https://en.wikipedia.org/wiki/Intermodal_container). They are:
+
+* capable of holding different cargo
+* can provide an isolated environment from the outside world
+* can be transported by various transport methods
+
+This is what we want for our project as well. We want to put whatever we want inside, we want it to be isolated and we want to be able to run it from anywhere.
+
+### Docker
+
+Docker can seem daunting at first.
 
 It works like this:
 
-1. Create a 'dockerfile'. This is like a plain-text recipe that will build from scratch everything you need for your project to run. It's just a textfile that you can put under version control.
-2. Run the dockerfile to generate a Docker 'image'. The image is an instance of the environment and everything you need to recreate your analysis. It's a delicious cake you made following the recipe.
-3. Other people can follow the dockerfile recipe to make their own copies of the delicious image cake. Each running instance of an image is called a container.
+1. Create a 'dockerfile'. This is like a plain-text recipe that will build from scratch everything you need to recreate a project. It's just a textfile that you can put under version control.
+1. Run the dockerfile to generate a Docker 'image'. The image is an instance of the environment and everything you need to recreate your analysis. It's a delicious cake you made following the recipe.
+1. Other people can follow the dockerfile recipe to make their own copies of the delicious image cake. Each running instance of an image is called a container.
 
 You can learn more about this process by [following the curriculum on Docker's website](https://docker-curriculum.com/). You can also read about the use of Docker [in the Department for Work and Pensions](https://dwpdigital.blog.gov.uk/2018/05/18/using-containers-to-deliver-our-data-projects/) (DWP). Phil Chapman [wrote more about the technical side of this process](https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/).
 

--- a/11-dependency.Rmd
+++ b/11-dependency.Rmd
@@ -1,6 +1,10 @@
-# Dependency management {#dep}
+# Dependency and reproducibility {#dep}
+
+_This section is in development. Please [contribute to the discussion](https://github.com/ukgovdatascience/rap_companion/issues/89)._
 
 ## The trouble with dependencies
+
+This section is about managing code written by other people, such as R or Python packages. It's important to consider how you're going to manage this code that your publication is _dependent_ on. Methods for doing this overlap with methods for reproducibility in general.
 
 ### Scheduled releases
 
@@ -12,7 +16,7 @@ Great. This means you have what you need to reproduce the publication when it's 
 
 ### Dependency hell
 
-A major problem is that you have _dependencies_ on other people's code. For example, you've probably imported packages or modules to perform analyses or create plots. This is powerful and useful, but the maintainers of that code can change it at any time. This means the software you used to produce your last release may have been updated.
+A major problem is that you have _dependencies_ on other people's code. For example, you've probably imported packages to perform analyses or create plots. This is powerful and useful, but the maintainers of that code can change it at any time. This means the software you used to produce your last release may have been updated.
 
 A maintainer should update the version number of their package when something changes. This could be a simple patch of an earlier version's bug (e.g. version 3.2.7 replaces 3.2.6), through to a major _breaking_ change (e.g. version 3.2.6 is update to version 4.0.0).
 
@@ -178,9 +182,11 @@ A similar tool to `packrat` is [the `checkpoint` package](https://github.com/Rev
 
 #### Virtual environments in Python
 
-Setting up an isolated environment -- also called a virtual environment -- is also an option in Python with things like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
+In Python we can create an isolated environment for our project and load packages into it.
 
-We can set up a virtual environment in our project folder, install any modules we need and then record them in a file for people to use in future. A shell script to do this might be:
+This is possible with tools like [`virtualenv` and `Pipenv`](https://docs.python-guide.org/dev/virtualenvs/).
+
+We can set up a virtual environment in our project folder, activate it, install any packages we need and then record them in a file for use in future. A shell script to do this might be:
 
 ```{bash, eval=FALSE}
 # 1. Navigate to your project folder
@@ -193,10 +199,10 @@ virtualenv venv
 source venv/bin/activate
 ```
 
-You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2. Lt's continue.
+You can now tell you're in the virtual environment because your shell prompt starts with `(venv)`, which is what we named our virtual environment folder (by convention) in step 2. Let's continue.
 
 ```{bash, eval=FALSE}
-# 4. Install the modules you need
+# 4. Install the packages you need, e.g. numpy
 pip install numpy
 
 # 5. Record the package-version list to a file in your home directory
@@ -206,50 +212,42 @@ pip freeze > requirements.txt
 deactivate
 ```
 
-When another user downloads your version-controlled project folder, the requirements.txt file will be there. Now they can create a virtual environment on their machine following steps 1 to 3 above, but rather than `pip install <module>` they can install based on the instructions from the requirements.txt file:
+When another user downloads your version-controlled project folder, the requirements.txt file will be there. Now they can create a virtual environment on their machine following steps 1 to 3 above, but rather than `pip install packageName` for each package they need, they can automate the process by installing everything from the requirements.txt file. From the shell:
 
 ```{bash, eval=FALSE}
 pip install -r requirements.txt
 ```
 
-This will download the modules one by one into the virtual environment.
+This will download the packages one by one into the virtual environment in their copy of the project virtual environment.
 
-## Another problem
+## Containers
 
-What about the version of the analytical software you're using? You may have written the original code in R version 3.4.1 but your computer is currently running R version 3.5.1. This is a similar problem to the issue of packages and modules: the functioning of code is also dependent on changes to the scripting tool itself.
+### Theory
 
-You can think bigger than an isolated environment for package installation. We need some kind of isolated environment for both the packages _and_ the tools. And why stop there? We could put our functions, tests and data in there too.
+Storing information about third-party packages is great, but there are still dependency management and reproduciblity issues. Collaborators could still encounter errors if they: 
 
-A 'container' for our publication is a good idea. We can isolate all the components of our RAP publication and make it even more reproducible and portable.
+* try to run your code in an later version of the language you used during development
+* use a different or updated Integrated Development Environment (IDE, like RStudio or Jupyter Notebooks)
+* try to re-run the analysis on a Linux machine but the original was developed on Windows, for example
 
-### Docker
+Fortunately, there are options to deal with this. One is [Docker](https://www.docker.com/), which effectively allows you to create a virtual computer inside your computer -- a _container_ -- with everything you need to recreate the anlysis under consistent conditions, regardless of who you are and what equipment you're using.
 
-One way of doing this is to use Docker.
+It works like this:
 
+1. Create a _dockerfile_. This is like a recipe that will build from scratch everything you need for your project to run. It's just a textfile that you can put under version control.
+2. Run the dockerfile to generate a Docker _image_. The image is an instance of the environment and everything you need to recreate your analysis. It's a delicious cake you made following the recipe.
+3. Other people can follow the dockerfile recipe to make their own copies of the delicious image cake. Each running instance of an image is called a _container_.
 
-General
+You can learn more about this process by [following the curriculum on Docker's website](https://docker-curriculum.com/). You can also read about the use of Docker [in the Department for Work and Pensions](https://dwpdigital.blog.gov.uk/2018/05/18/using-containers-to-deliver-our-data-projects/) (DWP). Phil Chapman [wrote more about the technical side of this process](https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/).
 
-* [GOV.UK on software dependencies](https://www.gov.uk/service-manual/technology/managing-software-dependencies)
-* [Docker for beginners](https://docker-curriculum.com/) by Docker
-* [Using containers to deliver our data projects](https://dwpdigital.blog.gov.uk/2018/05/18/using-containers-to-deliver-our-data-projects/), a DWP blog by Phil Chapman, and [a more in-depth personal blog](https://chapmandu2.github.io/post/2018/05/26/reproducible-data-science-environments-with-docker/) 
+### Make your life easier
 
-R-focused
+You don't have to build everything from scratch. [Docker hub](https://hub.docker.com/) is a big library of pre-prepared container images. For example, the [rocker project on Docker hub](https://hub.docker.com/u/rocker) lists a number of images containing R-specific tools like [rocker/tidyverse](https://hub.docker.com/r/rocker/tidyverse) that contains R, RStudio and [the tidyverse packages](https://tidyverse.tidyverse.org/). You can specify a rocker image in your dockerfile to make your life easier. Learn more about [rOpenSci labs tutorial](http://ropenscilabs.github.io/r-docker-tutorial/)
 
-* [An introduction to Docker for R users](https://colinfay.me/docker-r-reproducibility/) by Colin Fay
-* [Docker for the useR](https://github.com/noamross/nyhackr-docker-talk) by Noam Ross
-* [Production-ready R: Getting started with R and docker](https://www.youtube.com/watch?v=lfG8cTqRRNA) by Elizabeth Stark at UseR!2018 (YouTube)
-* [Applications with R and Docker](https://www.youtube.com/watch?v=JOIKy_89c-o) by Scott Came at UseR!2018 (YouTube)
-* [Rocker](https://hub.docker.com/u/rocker) on Docker Hub
-* [containerit](https://o2r.info/containerit/) packagedown site
-* [rOpenSci labs tutorial](http://ropenscilabs.github.io/r-docker-tutorial/)
+As well as rocker, R users can set up Docker from within an interactive R session: [the `containerit` package](https://o2r.info/containerit/index.html) lets you create a dockerfile given the current state of your session. This simplifies the process a great deal.
 
-Papers
-
-* [An Introduction to Rocker: Docker Containers for R](https://journal.r-project.org/archive/2017/RJ-2017-065/RJ-2017-065.pdf) in the R Journal, by Carl Boettiger and Dirk Eddelbuettel
-* [Reproducibility of computational workflows is automated using continuous analysis](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6103790/) in Nature Biotechnology
-Google Scholar search results
-
+R users can also read [Docker for the useR](https://github.com/noamross/nyhackr-docker-talk) by Noam Ross and [an introduction to Docker for R users](https://colinfay.me/docker-r-reproducibility/) by Colin Fay.
 
 [^sessionInfo]: There's also a `session_info()` function in each of the `devtools`, `xfun` and `sessioninfo` packages, which provide more detail on things like a package's source (e.g. CRAN or GitHub) and give the version number in a separate column.
-[^pip-pin]: These should be 'pinned' meaning that they're in the form `module==1.3.2` rather than `module>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.
+[^pip-pin]: These should be 'pinned' meaning that they're in the form `packageName==1.3.2` rather than `packageName>=1.3.2`. We're interested in storing _specific versions_, not _specific versions or newer_.
 [^save-session]: With something like `writeLines(capture.output(sessionInfo()), "sessionInfo.txt")` within R and `pip freeze > requirements.txt` in the shell for Python.


### PR DESCRIPTION
I've expanded chapter 11 (dependencies) from a stub to something more substantial. It talks through the theory and provides some approaches from merely recording session information, to package managers, to docker. I think this is good enough for now and we can iterate. Note that these commits are updates to the Rmd only; I've not re-knitted the book due to `packrat` problems (oh, the irony).